### PR TITLE
Update sample_events.R

### DIFF
--- a/R/sample_events.R
+++ b/R/sample_events.R
@@ -94,6 +94,7 @@ sample_events <- function(e, bins, ..., scaled.cols = NULL, col.names = NULL, dr
     e.assigned <- cbind(e.cut[keep, ], bin = bid[keep])
     # Apply the functions
     d <- do.call(cbind, lapply(functions, function(f) f(e.assigned)))
+    d <- d[order(as.numeric(row.names(d))),]
     # Reinsert empty bins as NA
     kept <- sort(unique(bid[keep]))
     if (drop.empty) {


### PR DESCRIPTION
This is an attempt to fix a bug which orders events incorrectly compared to their appropriate to and from bins. The newly inserted line of code reorders the events numerically based upon the row names in the dataframe (d).  Please review for more direct solutions.
